### PR TITLE
Add advanced operations, history, and offline support

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
         <div class="card" onclick="deleteLast()">DEL</div>
         <div class="card" onclick="insert('/')">/</div>
         <div class="card" onclick="insert('*')">*</div>
+        <div class="card" onclick="insert('**')">^</div>
+        <div class="card" onclick="squareRoot()">√</div>
+        <div class="card" onclick="percentage()">%</div>
         <div class="card" onclick="insert('7')">7</div>
         <div class="card" onclick="insert('8')">8</div>
         <div class="card" onclick="insert('9')">9</div>
@@ -32,7 +35,17 @@
         <div class="card" onclick="insert('0')">0</div>
         <div class="card" onclick="insert('.')">.</div>
     </div>
+    <div class="history-settings">
+        <label for="history-length">Historique (taille max):</label>
+        <input type="number" id="history-length" min="0" value="5" onchange="updateHistoryLength()">
+    </div>
+    <div id="history" class="history"></div>
 </div>
 <script src="script.js"></script>
+<script>
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+}
+</script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,4 @@
+// Gestion de l'affichage
 function clearScreen() {
     document.getElementById("result").value = "";
     document.getElementById("operation").innerText = "";
@@ -19,15 +20,88 @@ function insert(value) {
     operationField.innerText += value;
 }
 
+// Historique
+const HISTORY_KEY = "calcHistory";
+const HISTORY_LENGTH_KEY = "historyLength";
+let historyLength = parseInt(localStorage.getItem(HISTORY_LENGTH_KEY)) || 5;
+let history = JSON.parse(localStorage.getItem(HISTORY_KEY)) || [];
+
+function saveHistory() {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+}
+
+function renderHistory() {
+    const container = document.getElementById("history");
+    if (!container) return;
+    container.innerHTML = "";
+    history.forEach(item => {
+        const div = document.createElement("div");
+        div.textContent = item;
+        container.appendChild(div);
+    });
+    const input = document.getElementById("history-length");
+    if (input) input.value = historyLength;
+}
+
+document.addEventListener("DOMContentLoaded", renderHistory);
+
+function addToHistory(entry) {
+    history.unshift(entry);
+    if (history.length > historyLength) history.pop();
+    saveHistory();
+    renderHistory();
+}
+
+function updateHistoryLength() {
+    const input = document.getElementById("history-length");
+    historyLength = parseInt(input.value) || 0;
+    localStorage.setItem(HISTORY_LENGTH_KEY, historyLength);
+    history = history.slice(0, historyLength);
+    saveHistory();
+    renderHistory();
+}
+
+// Calculs avancés
+function squareRoot() {
+    let expression = document.getElementById("result").value || "0";
+    try {
+        let value = eval(expression);
+        if (value < 0) throw new Error("Valeur négative");
+        let result = Math.sqrt(value);
+        document.getElementById("result").value = result;
+        document.getElementById("operation").innerText = `√(${expression}) =`;
+        addToHistory(`√(${expression}) = ${result}`);
+    } catch (error) {
+        document.getElementById("result").value = "Erreur";
+        document.getElementById("operation").innerText = "";
+    }
+}
+
+function percentage() {
+    let expression = document.getElementById("result").value || "0";
+    try {
+        let value = eval(expression);
+        let result = value / 100;
+        document.getElementById("result").value = result;
+        document.getElementById("operation").innerText = `${expression}% =`;
+        addToHistory(`${expression}% = ${result}`);
+    } catch (error) {
+        document.getElementById("result").value = "Erreur";
+        document.getElementById("operation").innerText = "";
+    }
+}
+
 function calculate() {
     let expression = document.getElementById("result").value;
-    if (expression) {
-        try {
-            document.getElementById("result").value = eval(expression);
-            document.getElementById("operation").innerText = expression + " =";
-        } catch (error) {
-            document.getElementById("result").value = "Erreur";
-            document.getElementById("operation").innerText = "";
-        }
+    if (!expression) return;
+    try {
+        let result = eval(expression);
+        if (!isFinite(result)) throw new Error("Division par zéro");
+        document.getElementById("result").value = result;
+        document.getElementById("operation").innerText = expression + " =";
+        addToHistory(`${expression} = ${result}`);
+    } catch (error) {
+        document.getElementById("result").value = "Erreur";
+        document.getElementById("operation").innerText = "";
     }
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,31 @@
+const CACHE_NAME = 'calc-cache-v1';
+const URLS = [
+  '/',
+  'index.html',
+  'styles.css',
+  'script.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => {
+      return Promise.all(
+        keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+      );
+    })
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -66,3 +66,17 @@ input {
     background-color: #004d00;
     transform: translateY(-3px);
 }
+
+.history {
+    margin-top: 20px;
+    max-height: 150px;
+    overflow-y: auto;
+    background: #f9f9f9;
+    padding: 10px;
+    border-radius: 5px;
+    font-size: 14px;
+}
+
+.history-settings {
+    margin-top: 15px;
+}


### PR DESCRIPTION
## Summary
- add buttons and UI for advanced operations, history length, and offline service worker registration
- implement square root, power, percentage, history persistence, and improved error handling
- add service worker for offline caching
- update styles for history section

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683df3e134888322b836e0072bd62b1b