### PR TITLE
Fix history limit and adjust calculator appearance

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,31 +13,27 @@
         <input type="text" id="result" readonly>
     </div>
     <div class="buttons">
-        <div class="card" onclick="clearScreen()">C</div>
-        <div class="card" onclick="deleteLast()">DEL</div>
-        <div class="card" onclick="insert('/')">/</div>
-        <div class="card" onclick="insert('*')">*</div>
+        <div class="card light" onclick="clearScreen()">C</div>
+        <div class="card light" onclick="deleteLast()">DEL</div>
+        <div class="card light" onclick="insert('/')">/</div>
+        <div class="card light" onclick="insert('*')">*</div>
         <div class="card" onclick="insert('**')">^</div>
         <div class="card" onclick="squareRoot()">√</div>
         <div class="card" onclick="percentage()">%</div>
-        <div class="card" onclick="insert('7')">7</div>
-        <div class="card" onclick="insert('8')">8</div>
-        <div class="card" onclick="insert('9')">9</div>
-        <div class="card" onclick="insert('-')">-</div>
-        <div class="card" onclick="insert('4')">4</div>
-        <div class="card" onclick="insert('5')">5</div>
-        <div class="card" onclick="insert('6')">6</div>
-        <div class="card" onclick="insert('+')">+</div>
-        <div class="card" onclick="insert('1')">1</div>
-        <div class="card" onclick="insert('2')">2</div>
-        <div class="card" onclick="insert('3')">3</div>
-        <div class="card" onclick="calculate()">=</div>
+        <div class="card light" onclick="insert('7')">7</div>
+        <div class="card light" onclick="insert('8')">8</div>
+        <div class="card light" onclick="insert('9')">9</div>
+        <div class="card light" onclick="insert('-')">-</div>
+        <div class="card light" onclick="insert('4')">4</div>
+        <div class="card light" onclick="insert('5')">5</div>
+        <div class="card light" onclick="insert('6')">6</div>
+        <div class="card light" onclick="insert('+')">+</div>
+        <div class="card light" onclick="insert('1')">1</div>
+        <div class="card light" onclick="insert('2')">2</div>
+        <div class="card light" onclick="insert('3')">3</div>
+        <div class="card light" onclick="calculate()">=</div>
         <div class="card" onclick="insert('0')">0</div>
         <div class="card" onclick="insert('.')">.</div>
-    </div>
-    <div class="history-settings">
-        <label for="history-length">Historique (taille max):</label>
-        <input type="number" id="history-length" min="0" value="5" onchange="updateHistoryLength()">
     </div>
     <div id="history" class="history"></div>
 </div>

--- a/script.js
+++ b/script.js
@@ -22,9 +22,9 @@ function insert(value) {
 
 // Historique
 const HISTORY_KEY = "calcHistory";
-const HISTORY_LENGTH_KEY = "historyLength";
-let historyLength = parseInt(localStorage.getItem(HISTORY_LENGTH_KEY)) || 5;
+const HISTORY_LENGTH = 10; // taille fixe de l'historique
 let history = JSON.parse(localStorage.getItem(HISTORY_KEY)) || [];
+history = history.slice(0, HISTORY_LENGTH);
 
 function saveHistory() {
     localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
@@ -39,27 +39,17 @@ function renderHistory() {
         div.textContent = item;
         container.appendChild(div);
     });
-    const input = document.getElementById("history-length");
-    if (input) input.value = historyLength;
 }
 
 document.addEventListener("DOMContentLoaded", renderHistory);
 
 function addToHistory(entry) {
     history.unshift(entry);
-    if (history.length > historyLength) history.pop();
+    if (history.length > HISTORY_LENGTH) history.pop();
     saveHistory();
     renderHistory();
 }
 
-function updateHistoryLength() {
-    const input = document.getElementById("history-length");
-    historyLength = parseInt(input.value) || 0;
-    localStorage.setItem(HISTORY_LENGTH_KEY, historyLength);
-    history = history.slice(0, historyLength);
-    saveHistory();
-    renderHistory();
-}
 
 // Calculs avancés
 function squareRoot() {

--- a/styles.css
+++ b/styles.css
@@ -62,6 +62,15 @@ input {
     transition: background-color 0.2s, transform 0.2s;
 }
 
+.card.light {
+    background-color: #f5f5dc;
+    color: #000;
+}
+
+.card.light:hover {
+    background-color: #e0e0c0;
+}
+
 .card:hover {
     background-color: #004d00;
     transform: translateY(-3px);


### PR DESCRIPTION
## Summary
- remove history length configuration and fix size to 10 entries
- lighten number and main operator buttons

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683df6b0e57c8322b8f2a10591a58cb6