### PR TITLE
Improve calculator layout and history clearing

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,27 +13,32 @@
         <input type="text" id="result" readonly>
     </div>
     <div class="buttons">
-        <div class="card light" onclick="clearScreen()">C</div>
-        <div class="card light" onclick="deleteLast()">DEL</div>
+        <div class="card" onclick="clearScreen()">C</div>
+        <div class="card" onclick="deleteLast()">DEL</div>
+        <div class="card light" onclick="percentage()">%</div>
         <div class="card light" onclick="insert('/')">/</div>
-        <div class="card light" onclick="insert('*')">*</div>
-        <div class="card" onclick="insert('**')">^</div>
-        <div class="card" onclick="squareRoot()">√</div>
-        <div class="card" onclick="percentage()">%</div>
+
         <div class="card light" onclick="insert('7')">7</div>
         <div class="card light" onclick="insert('8')">8</div>
         <div class="card light" onclick="insert('9')">9</div>
-        <div class="card light" onclick="insert('-')">-</div>
+        <div class="card" onclick="insert('*')">*</div>
+
         <div class="card light" onclick="insert('4')">4</div>
         <div class="card light" onclick="insert('5')">5</div>
         <div class="card light" onclick="insert('6')">6</div>
-        <div class="card light" onclick="insert('+')">+</div>
+        <div class="card" onclick="insert('-')">-</div>
+
         <div class="card light" onclick="insert('1')">1</div>
         <div class="card light" onclick="insert('2')">2</div>
         <div class="card light" onclick="insert('3')">3</div>
-        <div class="card light" onclick="calculate()">=</div>
-        <div class="card" onclick="insert('0')">0</div>
-        <div class="card" onclick="insert('.')">.</div>
+        <div class="card" onclick="insert('+')">+</div>
+
+        <div class="card light" onclick="insert('0')">0</div>
+        <div class="card light" onclick="insert('.')">.</div>
+        <div class="card light" onclick="insert('**')">^</div>
+        <div class="card light" onclick="squareRoot()">√</div>
+
+        <div class="card" onclick="calculate()" style="grid-column: span 4;">=</div>
     </div>
     <div id="history" class="history"></div>
 </div>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,9 @@
 function clearScreen() {
     document.getElementById("result").value = "";
     document.getElementById("operation").innerText = "";
+    history = [];
+    saveHistory();
+    renderHistory();
 }
 
 function deleteLast() {


### PR DESCRIPTION
## Summary
- rearrange calculator buttons to mimic a traditional layout
- make operation buttons green and the zero button light
- clear calculation history when pressing **C**

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683df9dec9dc83228eb1c65c038e220f