### PR TITLE
Update multiplication and exponent buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <div class="card light" onclick="insert('7')">7</div>
         <div class="card light" onclick="insert('8')">8</div>
         <div class="card light" onclick="insert('9')">9</div>
-        <div class="card" onclick="insert('*')">*</div>
+        <div class="card" onclick="insert('*', 'X')">X</div>
 
         <div class="card light" onclick="insert('4')">4</div>
         <div class="card light" onclick="insert('5')">5</div>
@@ -35,7 +35,7 @@
 
         <div class="card light" onclick="insert('0')">0</div>
         <div class="card light" onclick="insert('.')">.</div>
-        <div class="card" onclick="insert('**')">^</div>
+        <div class="card" onclick="insert('**', 'Xʸ')">X&#x02B8;</div>
         <div class="card" onclick="squareRoot()">√</div>
 
         <div class="card" onclick="calculate()" style="grid-column: span 4;">=</div>

--- a/script.js
+++ b/script.js
@@ -18,12 +18,12 @@ function deleteLast() {
     operationField.innerText = operationField.innerText.slice(0, -1);
 }
 
-function insert(value) {
+function insert(value, displayValue = value) {
     let resultField = document.getElementById("result");
     let operationField = document.getElementById("operation");
 
     resultField.value += value;
-    operationField.innerText += value;
+    operationField.innerText += displayValue;
 }
 
 // Historique


### PR DESCRIPTION
## Summary
- customize calculator buttons
  - `*` button now shows `X` while still inserting `*`
  - exponent button displays `Xʸ` and inserts `**`
- adjust `insert` helper to accept an optional display value

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68402af4cbf88322bdc08ba359cd2bbd