### PR TITLE
Reorganize operation buttons and tweak history

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,28 +16,28 @@
         <div class="card" id="clearButton">C</div>
         <div class="card" onclick="deleteLast()">DEL</div>
         <div class="card" onclick="percentage()">%</div>
-        <div class="card" onclick="insert('/')">/</div>
+        <div class="card" onclick="squareRoot()">√</div>
 
         <div class="card light" onclick="insert('7')">7</div>
         <div class="card light" onclick="insert('8')">8</div>
         <div class="card light" onclick="insert('9')">9</div>
-        <div class="card" onclick="insert('*', 'X')">X</div>
+        <div class="card" onclick="insert('/')">/</div>
 
         <div class="card light" onclick="insert('4')">4</div>
         <div class="card light" onclick="insert('5')">5</div>
         <div class="card light" onclick="insert('6')">6</div>
-        <div class="card" onclick="insert('-')">-</div>
+        <div class="card" onclick="insert('*', 'X')">X</div>
 
         <div class="card light" onclick="insert('1')">1</div>
         <div class="card light" onclick="insert('2')">2</div>
         <div class="card light" onclick="insert('3')">3</div>
-        <div class="card" onclick="insert('+')">+</div>
+        <div class="card" onclick="insert('-')">-</div>
 
         <div class="card light" onclick="insert('0')">0</div>
         <div class="card light" onclick="insert('.')">.</div>
         <div class="card" onclick="insert('^', 'xʸ')">x&#x02B8;</div>
 
-        <div class="card" onclick="squareRoot()">√</div>
+        <div class="card" onclick="insert('+')">+</div>
 
         <div class="card" onclick="calculate()" style="grid-column: span 4;">=</div>
     </div>

--- a/script.js
+++ b/script.js
@@ -28,7 +28,7 @@ function insert(value, displayValue = value) {
 
 // Historique
 const HISTORY_KEY = "calcHistory";
-const HISTORY_LENGTH = 10; // taille fixe de l'historique
+const HISTORY_LENGTH = 9; // taille fixe de l'historique
 let history = JSON.parse(localStorage.getItem(HISTORY_KEY)) || [];
 history = history.slice(0, HISTORY_LENGTH);
 


### PR DESCRIPTION
## Summary
- rearrange order of operation buttons to rotate `/`, `*`, `-`, `+`, and `√`
- store only the 9 most recent operations

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68402f648ad88322a094deeeed66a3f4