### PR TITLE
Fix power button and add history reset

### DIFF
--- a/__tests__/evaluator.test.js
+++ b/__tests__/evaluator.test.js
@@ -29,6 +29,10 @@ describe('safeEval', () => {
     expect(window.CalculatorApp.safeEval('2+3*4')).toBe(14);
   });
 
+  test('computes power expression', () => {
+    expect(window.CalculatorApp.safeEval('2^3')).toBe(8);
+  });
+
   test('throws on invalid characters', () => {
     expect(() => window.CalculatorApp.safeEval('process.exit()')).toThrow();
   });

--- a/script.js
+++ b/script.js
@@ -18,12 +18,13 @@
   }
 
   function setupListeners() {
-    document.getElementById('clearButton').addEventListener('click', clearScreen);
+    const clearBtn = document.getElementById('clearButton');
+    clearBtn.addEventListener('click', clearScreen);
+    clearBtn.addEventListener('dblclick', clearHistory);
     document.getElementById('deleteButton').addEventListener('click', deleteLast);
     document.getElementById('percentageButton').addEventListener('click', percentage);
     document.getElementById('sqrtButton').addEventListener('click', squareRoot);
     document.getElementById('equalsButton').addEventListener('click', calculate);
-    document.getElementById('powerButton').addEventListener('click', () => handleOperator('^'));
 
     document.querySelectorAll('.number').forEach(btn => {
       btn.addEventListener('click', () => handleDigit(btn.dataset.value));
@@ -36,6 +37,12 @@
   function clearScreen() {
     elements.result.value = '';
     elements.operation.textContent = '';
+  }
+
+  function clearHistory() {
+    history = [];
+    saveHistory();
+    renderHistory();
   }
 
   function deleteLast() {


### PR DESCRIPTION
## Summary
- correct double `^` input by removing duplicate power button listener
- add clearHistory function
- allow double click on `C` button to clear history
- cover exponent in tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407e3f8a00832298fbe58942ec9862